### PR TITLE
Add pager oncall and pager oncall <schedule> commands

### DIFF
--- a/lib/lita-pagerduty.rb
+++ b/lib/lita-pagerduty.rb
@@ -1,7 +1,7 @@
 require 'lita'
 
 Lita.load_locales Dir[File.expand_path(
-    File.join('..', '..', 'locales', '*.yml'), __FILE__
+  File.join('..', '..', 'locales', '*.yml'), __FILE__
 )]
 
 require 'pagerduty'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -44,6 +44,12 @@ en:
           resolve_mine:
             syntax: pager resolve mine
             desc: Resolve all triggered incidents assigned to me
+          on_call_list:
+            syntax: pager oncall
+            desc: List available schedules
+          on_call_lookup:
+            syntax: pager oncall <schedule>
+            desc: Show who is on call for the given schedule
           whos_on_call:
             syntax: who's on call?
             desc: Show everyone currently on call (not implemented yet)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -75,3 +75,10 @@ en:
           resolved: "Resolved: %{list}"
         note:
           show: "%{id}: %{content} (%{email})"
+        on_call_list:
+          response: "Available schedules: %{schedules}"
+          no_schedules_found: "No schedules found"
+        on_call_lookup:
+          response: "%{name} (%{email}) is currently on call for %{schedule_name}"
+          no_matching_schedule: "No matching schedules found for '%{schedule_name}'" 
+          no_one_on_call: "No one is currently on call for %{schedule_name}"

--- a/spec/lita/handlers/pagerduty_utility_spec.rb
+++ b/spec/lita/handlers/pagerduty_utility_spec.rb
@@ -114,23 +114,15 @@ describe Lita::Handlers::PagerdutyUtility, lita_handler: true do
   end
 
   it do
-    is_expected.to route_command('who\'s on call').to(:whos_on_call)
-    is_expected.to route_command('who\'s on call?').to(:whos_on_call)
-    is_expected.to route_command('pager identify foobar@example.com')
-      .to(:identify)
+    is_expected.to route_command('pager oncall').to(:on_call_list)
+    is_expected.to route_command('pager oncall ops').to(:on_call_lookup)
+    is_expected.to route_command('pager identify foobar@example.com').to(:identify)
     is_expected.to route_command('pager forget').to(:forget)
   end
 
   before do
     Lita.config.handlers.pagerduty.api_key = 'foo'
     Lita.config.handlers.pagerduty.subdomain = 'bar'
-  end
-
-  describe '#whos_on_call' do
-    it 'shows a warning' do
-      send_command("who's on call?")
-      expect(replies.last).to eq('Not implemented yet.')
-    end
   end
 
   describe '#identify' do


### PR DESCRIPTION
Removes the `who's on call` command in favour of `pager oncall` and `pager oncall <schedule>`.

Usage:

```
lita > lita help pager oncall
lita: pager oncall - List available schedules
lita: pager oncall <schedule> - Show who is on call for the given schedule
lita > lita pager oncall
Available schedules: Primary Ops, Secondary Ops, Primary Data, Secondary Data
lita > lita pager oncall Primary Ops
Example User (user@example.com) is currently on call for Primary Ops
```