### PR TITLE
Separate schedules with newline

### DIFF
--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -54,7 +54,7 @@ module Lita
       def on_call_list(response)
         schedules = pd_client.get_schedules.schedules
         if schedules.any?
-          schedule_list = schedules.map(&:name).join(', ')
+          schedule_list = schedules.map(&:name).join("\n")
           response.reply(t('on_call_list.response', schedules: schedule_list))
         else
           response.reply(t('on_call_list.no_schedules_found'))

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -76,7 +76,7 @@ en:
         note:
           show: "%{id}: %{content} (%{email})"
         on_call_list:
-          response: "Available schedules: %{schedules}"
+          response: "Available schedules:\n%{schedules}"
           no_schedules_found: "No schedules found"
         on_call_lookup:
           response: "%{name} (%{email}) is currently on call for %{schedule_name}"


### PR DESCRIPTION
I'm sure it's best to start using the template functionality to get the best formatting support but this seems to increase readability in both the Shell and Slack adapters. If it's not the direction you want to head in, let me know and I can hack together something more compatible. Thanks!