### PR TITLE
Ignore case in on_call_lookup

### DIFF
--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -63,7 +63,7 @@ module Lita
 
       def on_call_lookup(response)
         schedule_name = response.match_data[1].strip
-        schedule = pd_client.get_schedules.schedules.find { |s| s.name == schedule_name }
+        schedule = pd_client.get_schedules.schedules.find { |s| s.casecmp(schedule_name) == 0 }
 
         unless schedule
           return response.reply(t('on_call_lookup.no_matching_schedule', schedule_name: schedule_name))


### PR DESCRIPTION
I feel it might be a common case to prefer more lax lookup of schedules

```
> pager oncall
Foo bar BAZ
```

```
pager oncall foo
...
pager oncall bar
...
pager oncall baz
...
```

If not, I'm happy to make this a configuration option. I could see this being an issue if you can create schedules that only differ in the case of the name but separate schedules named `PROD` and `Prod` seems like a recipe for disaster.