### PR TITLE
changing regex as pagerduty incident ids can be > 6 characters

### DIFF
--- a/lib/pagerduty_helper/regex.rb
+++ b/lib/pagerduty_helper/regex.rb
@@ -2,7 +2,7 @@
 module PagerdutyHelper
   # Utility functions
   module Regex
-    INCIDENT_ID_PATTERN = /(?<incident_id>[a-zA-Z0-9+]{1,6})/
+    INCIDENT_ID_PATTERN = /(?<incident_id>[a-zA-Z0-9+]+)/
     EMAIL_PATTERN       = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
   end
 end

--- a/spec/lita/handlers/pagerduty_incident_spec.rb
+++ b/spec/lita/handlers/pagerduty_incident_spec.rb
@@ -78,5 +78,14 @@ describe Lita::Handlers::PagerdutyIncident, lita_handler: true do
         expect(replies.last).to eq('ABC123: Incident not found')
       end
     end
+
+    describe 'when the incident id is longer than 6 characters' do
+      it 'shows the incident details' do
+        expect(Pagerduty).to receive(:new) { incident_with_long_id }
+        send_command('pager incident ABC123456789')
+        expect(replies.last).to eq('ABC123456789: "something broke", ' \
+                                   'assigned to: foo@example.com')
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -171,4 +171,17 @@ RSpec.shared_context 'basic fixtures' do
     end
     client
   end
+
+  let(:incident_with_long_id) do
+    client = double
+    expect(client).to receive(:get_incident) do
+      double(
+        id: 'ABC123456789',
+        status: 'triggered',
+        trigger_summary_data: double(subject: 'something broke'),
+        assigned_to_user: double(email: 'foo@example.com')
+      )
+    end
+    client
+  end
 end


### PR DESCRIPTION
I started using lita-pagerduty for our pagerduty setup - we have incidents which are more than 6 characters while the lita pd bot limits them to 6 characters. I tried searching for a PD regex for incidents but couldn't find any. Safer way is to have 1 or more of the allowed characters as a valid regex. 