### PR TITLE
Dont crash on nil assigned user

### DIFF
--- a/lib/pagerduty_helper/incident.rb
+++ b/lib/pagerduty_helper/incident.rb
@@ -5,6 +5,7 @@ module PagerdutyHelper
     def format_incident(incident)
       t('incident.info', id: incident.id,
                          subject: incident.trigger_summary_data.subject,
+                         url: incident.html_url,
                          assigned: incident.assigned_to_user.email)
     end
 

--- a/lib/pagerduty_helper/incident.rb
+++ b/lib/pagerduty_helper/incident.rb
@@ -6,7 +6,7 @@ module PagerdutyHelper
       t('incident.info', id: incident.id,
                          subject: incident.trigger_summary_data.subject,
                          url: incident.html_url,
-                         assigned: incident.assigned_to_user.email)
+                         assigned: incident.assigned_to_user.nil? ? "none" : incident.assigned_to_user.email)
     end
 
     def resolve_incident(incident_id)

--- a/lib/pagerduty_helper/regex.rb
+++ b/lib/pagerduty_helper/regex.rb
@@ -2,7 +2,7 @@
 module PagerdutyHelper
   # Utility functions
   module Regex
-    INCIDENT_ID_PATTERN = /(?<incident_id>[a-zA-Z0-9+]{1,6})/
+    INCIDENT_ID_PATTERN = /(?<incident_id>[a-zA-Z0-9+]+)/
     EMAIL_PATTERN       = /(?<email>[\w+\-.]+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+)/i
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -66,7 +66,7 @@ en:
           resolved: "%{id}: Incident resolved"
           unable_to_acknowledge: "%{id}: Unable to acknowledge incident"
           unable_to_resolve: "%{id}: Unable to resolve incident"
-          info: "%{id}: \"%{subject}\", assigned to: %{assigned}"
+          info: "%{id}: \"%{subject}\", assigned to: %{assigned}, url: %{url}"
         forget:
           complete: Your email has now been forgotten.
           unknown: No email on record for you.


### PR DESCRIPTION
If an incident is not assigned to anyone the incident.assigned_to_user.email fails as assigned_to_user is nil - causing a plugin crash. Added check to have placeholder "none" if the incident isn't assigned. 