### PR TITLE
Adding url in incident desc

### DIFF
--- a/lib/pagerduty_helper/incident.rb
+++ b/lib/pagerduty_helper/incident.rb
@@ -5,6 +5,7 @@ module PagerdutyHelper
     def format_incident(incident)
       t('incident.info', id: incident.id,
                          subject: incident.trigger_summary_data.subject,
+                         url: incident.html_url,
                          assigned: incident.assigned_to_user.email)
     end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -66,7 +66,7 @@ en:
           resolved: "%{id}: Incident resolved"
           unable_to_acknowledge: "%{id}: Unable to acknowledge incident"
           unable_to_resolve: "%{id}: Unable to resolve incident"
-          info: "%{id}: \"%{subject}\", assigned to: %{assigned}"
+          info: "%{id}: \"%{subject}\", assigned to: %{assigned}, url: %{url}"
         forget:
           complete: Your email has now been forgotten.
           unknown: No email on record for you.

--- a/spec/lita/handlers/pagerduty_incident_spec.rb
+++ b/spec/lita/handlers/pagerduty_incident_spec.rb
@@ -15,7 +15,7 @@ describe Lita::Handlers::PagerdutyIncident, lita_handler: true do
         expect(Pagerduty).to receive(:new) { incidents }
         send_command('pager incidents all')
         expect(replies.last).to eq('ABC789: "Still broke", assigned to: '\
-                                   'bar@example.com')
+                                   'bar@example.com, url: https://acme.pagerduty.com/incidents/ABC789')
       end
     end
 
@@ -37,7 +37,7 @@ describe Lita::Handlers::PagerdutyIncident, lita_handler: true do
         send_command('pager identify bar@example.com', as: bar)
         send_command('pager incidents mine', as: bar)
         expect(replies.last).to eq('ABC789: "Still broke", assigned to: ' \
-                                   'bar@example.com')
+                                   'bar@example.com, url: https://acme.pagerduty.com/incidents/ABC789')
       end
     end
 
@@ -67,7 +67,8 @@ describe Lita::Handlers::PagerdutyIncident, lita_handler: true do
         expect(Pagerduty).to receive(:new) { new_incident }
         send_command('pager incident ABC123')
         expect(replies.last).to eq('ABC123: "something broke", ' \
-                                   'assigned to: foo@example.com')
+                                   'assigned to: foo@example.com, ' \
+                                   'url: https://acme.pagerduty.com/incidents/ABC123')
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,12 +61,14 @@ RSpec.shared_context 'basic fixtures' do
           double(
             id: 'ABC123',
             status: 'resolved',
+            html_url: 'https://acme.pagerduty.com/incidents/ABC123',
             trigger_summary_data: double(subject: 'something broke'),
             assigned_to_user: double(email: 'foo@example.com')
           ),
           double(
             id: 'ABC789',
             status: 'triggered',
+            html_url: 'https://acme.pagerduty.com/incidents/ABC789',
             trigger_summary_data: double(subject: 'Still broke'),
             assigned_to_user: double(email: 'bar@example.com')
           )
@@ -76,6 +78,7 @@ RSpec.shared_context 'basic fixtures' do
     allow(client).to receive(:get_incident) do
       double(
         status: 'triggered',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC789',
         trigger_summary_data: double(subject: 'Still broke'),
         assigned_to_user: double(email: 'bar@example.com'),
         acknowledge: { 'id' => 'ABC789', 'status' => 'acknowledged' },
@@ -92,6 +95,7 @@ RSpec.shared_context 'basic fixtures' do
       double(
         id: 'ABC123',
         status: 'triggered',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         trigger_summary_data: double(subject: 'something broke'),
         assigned_to_user: double(email: 'foo@example.com'),
         acknowledge: { 'id' => 'ABC123', 'status' => 'acknowledged' },
@@ -107,6 +111,7 @@ RSpec.shared_context 'basic fixtures' do
     expect(client).to receive(:get_incident) do
       double(
         status: 'acknowledged',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         trigger_summary_data: double(subject: 'something broke'),
         assigned_to_user: double(email: 'foo@example.com'),
         acknowledge: { 'error' =>
@@ -124,6 +129,7 @@ RSpec.shared_context 'basic fixtures' do
     expect(client).to receive(:get_incident) do
       double(
         status: 'resolved',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         trigger_summary_data: double(subject: 'something broke'),
         assigned_to_user: double(email: 'foo@example.com'),
         notes: double(notes: [])
@@ -137,6 +143,7 @@ RSpec.shared_context 'basic fixtures' do
     expect(client).to receive(:get_incident) do
       double(
         status: 'notresolved',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         resolve:  { 'id' => 'ABC123', 'status' => 'notresolved' }
       )
     end
@@ -148,6 +155,7 @@ RSpec.shared_context 'basic fixtures' do
     expect(client).to receive(:get_incident) do
       double(
         status: 'notacked',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         acknowledge: { 'error' => {} },
         resolve:  { 'id' => 'ABC123', 'status' => 'notacked' }
       )
@@ -161,6 +169,7 @@ RSpec.shared_context 'basic fixtures' do
       double(
         id: 'ABC123',
         status: 'resolved',
+        html_url: 'https://acme.pagerduty.com/incidents/ABC123',
         trigger_summary_data: double(subject: 'something broke'),
         assigned_to_user: double(email: 'foo@example.com'),
         notes: double(


### PR DESCRIPTION
Adding url in incident description can help the user jump to the url if he wants to see more details. Added tests for the same. 