### PR TITLE
checking if assigned_user is nil before accessing email attr

### DIFF
--- a/lib/pagerduty_helper/incident.rb
+++ b/lib/pagerduty_helper/incident.rb
@@ -5,7 +5,7 @@ module PagerdutyHelper
     def format_incident(incident)
       t('incident.info', id: incident.id,
                          subject: incident.trigger_summary_data.subject,
-                         assigned: incident.assigned_to_user.email)
+                         assigned: incident.assigned_to_user.nil? ? 'none' : incident.assigned_to_user.email)
     end
 
     def resolve_incident(incident_id)

--- a/spec/lita/handlers/pagerduty_incident_spec.rb
+++ b/spec/lita/handlers/pagerduty_incident_spec.rb
@@ -78,5 +78,14 @@ describe Lita::Handlers::PagerdutyIncident, lita_handler: true do
         expect(replies.last).to eq('ABC123: Incident not found')
       end
     end
+
+    describe 'when the incident is not assigned to anyone' do
+      it 'shows incident details with none user' do
+        expect(Pagerduty).to receive(:new) { incident_without_assigned_user }
+        send_command('pager incident ABC456')
+        expect(replies.last).to eq('ABC456: "something broke", ' \
+                                   'assigned to: none')
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,6 +102,19 @@ RSpec.shared_context 'basic fixtures' do
     client
   end
 
+  let(:incident_without_assigned_user) do
+    client = double
+    expect(client).to receive(:get_incident) do
+      double(
+        id: 'ABC456',
+        status: 'triggered',
+        trigger_summary_data: double(subject: 'something broke'),
+        assigned_to_user: nil
+      )
+    end
+    client
+  end
+
   let(:acknowledged_incident) do
     client = double
     expect(client).to receive(:get_incident) do


### PR DESCRIPTION
If the assigned_user for the incident is nil - accessing email attr of nil causes the plugin to silently crash behind the scenes, adding placeholder value none to avoid this.