### PR TITLE
qualify access to Time.now

### DIFF
--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -96,7 +96,7 @@ module Lita
       private
 
       def lookup_on_call_user(schedule_id)
-        now = Time.now.utc
+        now = Time::Time.now.utc
         pd_client.get_schedule_users(
           id: schedule_id,
           since: now.iso8601,

--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -96,7 +96,7 @@ module Lita
       private
 
       def lookup_on_call_user(schedule_id)
-        now = Time::Time.now.utc
+        now = ::Time.now.utc
         pd_client.get_schedule_users(
           id: schedule_id,
           since: now.iso8601,


### PR DESCRIPTION
I was getting the following error when running `lita pager oncall xxx`
ERROR: Lita::Handlers::PagerdutyUtility crashed. The exception was:
undefined method `now' for Lita::Handlers::Time:Class

Qualifying the reference to Time.now seems to fix.