### PR TITLE
Fix Issue #8 by adding support for taking the pager

### DIFF
--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -51,6 +51,13 @@ module Lita
         }
       )
 
+      route(
+        /^pager\s+me\s+(\w+)\s+(\d+)m?$/,
+        :pager_me,
+        command: true,
+        help: { t('help.pager_me.syntax') => t('help.pager_me.desc') }
+      )
+
       def on_call_list(response)
         schedules = pd_client.get_schedules.schedules
         if schedules.any?
@@ -75,6 +82,25 @@ module Lita
         else
           response.reply(t('on_call_lookup.no_one_on_call', schedule_name: schedule_name))
         end
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # rubocop:disable Metrics/AbcSize
+      def pager_me(response)
+        schedule_name = response.match_data[1].strip
+        schedule = pd_client.get_schedules.schedules.find { |s| s.name.casecmp(schedule_name) == 0 }
+        return response.reply(t('on_call_lookup.no_matching_schedule', schedule_name: schedule_name)) unless schedule
+
+        email = fetch_user(response.user)
+        return response.reply(t('identify.missing')) unless email
+
+        users = pd_client.get_users(query: email)
+        return response.reply(t('identify.unrecognised')) unless users.total == 1
+
+        override = take_pager(schedule.id, users.users.first.id, response.match_data[2].strip.to_i)
+        return response.reply(t('pager_me.failure')) unless override
+
+        response.reply(t('pager_me.success', name: override.user.name, email: override.user.email, finish: override.end))
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -52,7 +52,7 @@ module Lita
       )
 
       route(
-        /^pager\s+me\s+(\w+)\s+(\d+)m?$/,
+        /^pager\s+me\s+(.+?)\s+(\d+)m?$/,
         :pager_me,
         command: true,
         help: { t('help.pager_me.syntax') => t('help.pager_me.desc') }

--- a/lib/pagerduty_helper/utility.rb
+++ b/lib/pagerduty_helper/utility.rb
@@ -25,5 +25,19 @@ module PagerdutyHelper
     def format_user(user)
       "email_#{user.id}"
     end
+
+    def take_pager(schedule_id, user_id, duration_mins)
+      from = ::Time.now.utc + 10
+      to = from + (60 * duration_mins)
+
+      pd_client.create_schedule_override(
+        id: schedule_id,
+        override: {
+          user_id: user_id,
+          start: from.iso8601,
+          end: to.iso8601
+        }
+      )
+    end
   end
 end

--- a/lita-pagerduty.gemspec
+++ b/lita-pagerduty.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
-  spec.add_runtime_dependency 'pagerduty-sdk', '>= 1.0.7'
+  spec.add_runtime_dependency 'pagerduty-sdk', '>= 1.0.9'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls'

--- a/lita-pagerduty.gemspec
+++ b/lita-pagerduty.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.0'
-  spec.add_runtime_dependency 'pagerduty-sdk'
+  spec.add_runtime_dependency 'pagerduty-sdk', '>= 1.0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'coveralls'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,10 +53,14 @@ en:
           whos_on_call:
             syntax: who's on call?
             desc: Show everyone currently on call (not implemented yet)
+          pager_me:
+            syntax: pager me <schedule> <minutes>
+            desc: Take the pager for the given schedule for the specified number of minutes
         identify:
           already: You have already been identified!
           complete: You have now been identified.
           missing: You have not identified yourself (use the help command for more info)
+          unrecognised: You have identified yourself with an email address unknown to PagerDuty
         incident:
           acknowledged: "%{id}: Incident acknowledged"
           already_set: "%{id}: Incident already %{status}"
@@ -82,3 +86,6 @@ en:
           response: "%{name} (%{email}) is currently on call for %{schedule_name}"
           no_matching_schedule: "No matching schedules found for '%{schedule_name}'" 
           no_one_on_call: "No one is currently on call for %{schedule_name}"
+        pager_me:
+          success: "%{name} (%{email}) is now on call until %{finish}"
+          failure: "failed to take the pager"

--- a/spec/lita/handlers/pagerduty_utility_spec.rb
+++ b/spec/lita/handlers/pagerduty_utility_spec.rb
@@ -8,6 +8,7 @@ describe Lita::Handlers::PagerdutyUtility, lita_handler: true do
     is_expected.to route_command('pager oncall ops').to(:on_call_lookup)
     is_expected.to route_command('pager identify foobar@example.com').to(:identify)
     is_expected.to route_command('pager forget').to(:forget)
+    is_expected.to route_command('pager me ops 12m').to(:pager_me)
   end
 
   before do


### PR DESCRIPTION
This pull request adds support for taking the pager, as requested in issue #8.

In order to support this, we need to take a newer version of the pagerduty-sdk gem **that has not been published yet**.  Once https://github.com/kryptek/pagerduty-sdk/pull/10 has been merged and published then this pull request should be a candidate for merging.