### PR TITLE
[misc] Add automatic identification if a service supports it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ FileName:
 
 LineLength:
   Max: 130
+
+ClassLength:
+  Max: 130

--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ pager resolve <incident ID>        - Resolve a specific incident
 ### Schedules
 
 ```
-pager oncall - List available schedules
-pager oncall <schedule> - Show who is on call for the given schedule
+pager oncall                       - List available schedules
+pager oncall <schedule>            - Show who is on call for the given schedule
 ```
 
 ### Misc
 
 ```
-pager identify <email address>     - Associate your chat user with your email address
+pager identify <email address>     - Associate your chat user with your email address (only needed on chat services that don't automatically provide it)
+pager whoami                       - Shows what email address is associated with your chat user
 pager forget                       - Remove your chat user / email association
 ```
 

--- a/lib/lita/handlers/pagerduty_utility.rb
+++ b/lib/lita/handlers/pagerduty_utility.rb
@@ -52,6 +52,15 @@ module Lita
       )
 
       route(
+        /^pager\swhoami$/,
+        :whoami,
+        command: true,
+        help: {
+          t('help.whoami.syntax') => t('help.whoami.desc')
+        }
+      )
+
+      route(
         /^pager\s+me\s+(.+?)\s+(\d+)m?$/,
         :pager_me,
         command: true,
@@ -117,6 +126,12 @@ module Lita
         return response.reply(t('forget.unknown')) unless stored_email
         delete_user(response.user)
         response.reply(t('forget.complete'))
+      end
+
+      def whoami(response)
+        user = fetch_user(response.user)
+        return response.reply(t('whoami.unknown')) if user.nil?
+        response.reply(t('whoami.known', email: user))
       end
 
       private

--- a/lib/pagerduty_helper/utility.rb
+++ b/lib/pagerduty_helper/utility.rb
@@ -15,7 +15,12 @@ module PagerdutyHelper
     end
 
     def fetch_user(user)
-      redis.get(format_user(user))
+      result = redis.get(format_user(user))
+      if result.nil? && user.metadata['email']
+        store_user(user, user.metadata['email'].to_s)
+        return redis.get(format_user(user))
+      end
+      result
     end
 
     def delete_user(user)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -56,6 +56,9 @@ en:
           pager_me:
             syntax: pager me <schedule> <minutes>
             desc: Take the pager for the given schedule for the specified number of minutes
+          whoami:
+            syntax: pager whoami
+            desc: Show the users's email address if they have been identified
         identify:
           already: You have already been identified!
           complete: You have now been identified.
@@ -84,8 +87,11 @@ en:
           no_schedules_found: "No schedules found"
         on_call_lookup:
           response: "%{name} (%{email}) is currently on call for %{schedule_name}"
-          no_matching_schedule: "No matching schedules found for '%{schedule_name}'" 
+          no_matching_schedule: "No matching schedules found for '%{schedule_name}'"
           no_one_on_call: "No one is currently on call for %{schedule_name}"
         pager_me:
           success: "%{name} (%{email}) is now on call until %{finish}"
           failure: "failed to take the pager"
+        whoami:
+          known: "You have been identified as %{email}"
+          unknown: You have not been identified

--- a/spec/lita/handlers/pagerduty_utility_spec.rb
+++ b/spec/lita/handlers/pagerduty_utility_spec.rb
@@ -8,6 +8,7 @@ describe Lita::Handlers::PagerdutyUtility, lita_handler: true do
     is_expected.to route_command('pager oncall ops').to(:on_call_lookup)
     is_expected.to route_command('pager identify foobar@example.com').to(:identify)
     is_expected.to route_command('pager forget').to(:forget)
+    is_expected.to route_command('pager whoami').to(:whoami)
     is_expected.to route_command('pager me ops 12m').to(:pager_me)
   end
 
@@ -54,6 +55,26 @@ describe Lita::Handlers::PagerdutyUtility, lita_handler: true do
         send_command('pager forget', as: foo)
         expect(replies.last).to eq('No email on record for you.')
       end
+    end
+  end
+
+  describe '#whoami' do
+    it 'shows the user when associated' do
+      foo = Lita::User.create(123, name: 'foo')
+      send_command('pager identify foo@example.com', as: foo)
+      send_command('pager whoami', as: foo)
+      expect(replies.last).to eq('You have been identified as foo@example.com')
+    end
+
+    it 'shows the user automatically if they have an email attribute' do
+      foo = Lita::User.create(123, name: 'foo', email: 'foo@example.com')
+      send_command('pager whoami', as: foo)
+      expect(replies.last).to eq('You have been identified as foo@example.com')
+    end
+
+    it 'shows a warning when that user is not associated' do
+      send_command('pager whoami')
+      expect(replies.last).to eq('You have not been identified')
     end
   end
 end


### PR DESCRIPTION
Some chat services (Slack for example) supply user email addresses as part
of the metadata available to Lita.  This adds code to automatically use
that information if it's available, and a helper whoami command for people
to debug if their Slack email != their PagerDuty email.
