### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ gem "lita-pagerduty"
 
 ## Configuration
 
+Create a PagerDuty api Key(v1 legacy) You will need to give it FullAccess to update incidents
+
 Add the following variables to your Lita config file:
 
 ``` ruby


### PR DESCRIPTION
Updating Readme to specify a v1Legacy API key should be used for this integration. V2 does not work
