### PR TITLE
Teams filtering support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 *.gem
 *.rbc
 *.swp

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [PagerDuty](http://pagerduty.com) plugin for [Lita](https://github.com/jimmycu
 
 Add lita-pagerduty to your Lita instance's Gemfile:
 
-``` ruby
+```ruby
 gem "lita-pagerduty"
 ```
 
@@ -23,9 +23,16 @@ Create a PagerDuty api Key(v1 legacy) You will need to give it FullAccess to upd
 
 Add the following variables to your Lita config file:
 
-``` ruby
+```ruby
 config.handlers.pagerduty.api_key = ''
 config.handlers.pagerduty.email   = ''
+```
+
+If your account has the teams capability and you want to scope Lita's access to a specific set of
+teams, you can set the list of teams by adding the following to your config file:
+
+```ruby
+config..handlers.pagerduty.teams = [ "team-a", "team-b" ]
 ```
 
 ## Usage

--- a/lib/lita/commands/base.rb
+++ b/lib/lita/commands/base.rb
@@ -65,7 +65,7 @@ module Commands
     end
 
     def pagerduty
-      @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email)
+      @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email, config.teams)
     end
 
     def store

--- a/lib/lita/commands/base.rb
+++ b/lib/lita/commands/base.rb
@@ -65,7 +65,12 @@ module Commands
     end
 
     def pagerduty
-      @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email, config.teams)
+      @pagerduty ||= ::Pagerduty.new(
+        http,
+        config.api_key,
+        config.email,
+        config.teams
+      )
     end
 
     def store

--- a/lib/lita/handlers/pagerduty.rb
+++ b/lib/lita/handlers/pagerduty.rb
@@ -33,7 +33,12 @@ module Lita
       end
 
       def pagerduty
-        @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email, config.teams)
+        @pagerduty ||= ::Pagerduty.new(
+          http,
+          config.api_key,
+          config.email,
+          config.teams
+        )
       end
 
       def store

--- a/lib/lita/handlers/pagerduty.rb
+++ b/lib/lita/handlers/pagerduty.rb
@@ -4,6 +4,7 @@ module Lita
       namespace 'Pagerduty'
       config :api_key, required: true
       config :email, required: true
+      config :teams, required: false
 
       COMMANDS_PATH = File.read("#{File.dirname(__FILE__)}/commands.yml")
       COMMANDS = YAML.safe_load(COMMANDS_PATH)
@@ -32,7 +33,7 @@ module Lita
       end
 
       def pagerduty
-        @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email)
+        @pagerduty ||= ::Pagerduty.new(http, config.api_key, config.email, config.teams)
       end
 
       def store

--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -1,57 +1,49 @@
 class Pagerduty
-  def initialize(http, token, email)
-    @token = token
+  attr_reader :http, :teams
+
+  def initialize(http, token, email, teams = [])
     @http = http
+    @teams = teams || []
+
     http.url_prefix = 'https://api.pagerduty.com/'
-    http.headers = headers(email)
+    http.headers = auth_headers(email, token)
   end
 
   def get_incidents(params = {})
-    response = @http.get '/incidents', params
-    data = JSON.parse(response.body, symbolize_names: true)
-               .fetch(:incidents, [])
+    data = get_resources(:incidents, params)
     raise Exceptions::IncidentsEmptyList if data.empty?
-
     data
   end
 
   def get_users(params = {})
-    response = @http.get '/users', params
-    data = JSON.parse(response.body, symbolize_names: true).fetch(:users, [])
+    data = get_resources(:users, params)
     raise Exceptions::UsersEmptyList if data.empty?
-
     data
   end
 
   def get_schedules(params = {})
-    response = @http.get '/schedules', params
-    data = JSON.parse(response.body, symbolize_names: true)
-               .fetch(:schedules, [])
+    data = get_resources(:schedules, params)
     raise Exceptions::SchedulesEmptyList if data.empty?
-
     data
   end
 
   def get_oncall_user(params = {})
-    response = @http.get '/oncalls', params
-    data = JSON.parse(response.body, symbolize_names: true).fetch(:oncalls, [])
+    data = get_resources(:oncalls, params)
     raise Exceptions::NoOncallUser if data.empty?
-
     data.first.fetch(:user)
   end
 
   def get_incident(id = '404stub')
-    response = @http.get "/incidents/#{id}"
+    response = http.get "/incidents/#{id}"
     raise Exceptions::IncidentNotFound if response.status == 404
-
-    JSON.parse(response.body, symbolize_names: true).fetch(:incident, nil)
+    parse_json_response(response, :incident)
   end
 
   def get_notes_by_incident_id(incident_id)
-    response = @http.get "/incidents/#{incident_id}/notes"
+    response = http.get "/incidents/#{incident_id}/notes"
     raise Exceptions::IncidentNotFound if response.status == 404
 
-    data = JSON.parse(response.body, symbolize_names: true).fetch(:notes, [])
+    data = parse_json_response(response, :notes, [])
     raise Exceptions::NotesEmptyList if data.empty?
 
     data
@@ -62,7 +54,7 @@ class Pagerduty
       { id: id, type: 'incident_reference', status: "#{action}d" }
     end
     payload = { incidents: incidents }
-    response = @http.put '/incidents', payload
+    response = http.put '/incidents', payload
     raise Exceptions::IncidentManageUnsuccess if response.status != 200
 
     response
@@ -76,7 +68,7 @@ class Pagerduty
       end: to.iso8601,
       user: { id: user_id, type: 'user_reference' }
     } }
-    response = @http.post "/schedules/#{schedule_id}/overrides", payload
+    response = http.post "/schedules/#{schedule_id}/overrides", payload
     raise Exceptions::OverrideUnsuccess if response.status != 201
 
     JSON.parse(response.body, symbolize_names: true).fetch(:override, nil)
@@ -84,11 +76,30 @@ class Pagerduty
 
   private
 
-  def headers(email)
+  def auth_headers(email, token)
     {
       'Accept' => 'application/vnd.pagerduty+json;version=2',
-      'Authorization' => "Token token=#{@token}",
+      'Authorization' => "Token token=#{token}",
       'From' => email
     }
   end
+
+  # Fetches a list of resources from a given collection using Pagerduty REST v2 API
+  def get_resources(collection_name, params = {})
+    # Scope down to a single team
+    params.merge!(team_ids: teams) if teams.any?
+
+    # Get the resources
+    response = http.get "/#{collection_name}", params
+
+    # Parse the reponse and get the objects from the collection
+    parse_json_response(response, collection_name, [])
+  end
+
+  # Parses a JSON response and fetches a specific key from it
+  def parse_json_response(response, response_key, default_value = nil)
+    data = JSON.parse(response.body, symbolize_names: true)
+    data.fetch(response_key, default_value)
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+# We rely on timezone being in UTC
+ENV['TZ'] = 'UTC'
+
 require 'simplecov'
 require 'coveralls'
 SimpleCov.formatters = [


### PR DESCRIPTION
This PR adds support for teams-based filtering to all operations performed by Lita on a given Pagerduty account.

Specify the list of teams as `config.handlers.pagerduty.teams` and the bot is going to only touch resources belonging to those teams. This is extremely useful for large Pagerduty accounts shared by many teams and Lita being deployed for a subset of teams only.