### PR TITLE
Fix help text not pulling localized strings

### DIFF
--- a/lib/lita-pagerduty.rb
+++ b/lib/lita-pagerduty.rb
@@ -1,14 +1,16 @@
 require 'lita'
+
+Lita.load_locales Dir[File.expand_path(
+  File.join('..', '..', 'locales', '*.yml'), __FILE__
+)]
+
 require 'exceptions'
 require 'pagerduty'
 require 'store'
 require 'lita/handlers/pagerduty'
 require 'lita/commands/base'
-Dir[File.join(__dir__, 'lita', 'commands', '*.rb')].each { |file| require file }
 
-Lita.load_locales Dir[File.expand_path(
-  File.join('..', '..', 'locales', '*.yml'), __FILE__
-)]
+Dir[File.join(__dir__, 'lita', 'commands', '*.rb')].each { |file| require file }
 
 Lita::Handlers::Pagerduty.template_root File.expand_path(
   File.join('..', '..', 'templates'), __FILE__

--- a/lib/lita/handlers/pagerduty.rb
+++ b/lib/lita/handlers/pagerduty.rb
@@ -13,8 +13,8 @@ module Lita
           command['method'].to_sym,
           command: true,
           help: {
-            "help.#{command['method']}.syntax" =>
-              "help.#{command['method']}.desc"
+            t("help.#{command['method']}.syntax") =>
+              t("help.#{command['method']}.desc")
           }
         )
       end


### PR DESCRIPTION
- Use t() to load the localized strings.
- Load localized strings before setting up routes, since otherwise the
  localized strings aren't available at the time the class is created.